### PR TITLE
Improve accuracy of inter loop shift elision example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Funki Crab can elide shifts across loop boundaries.
 
 Example:
 
-`+<<[>]`
+`+<<[>]>>`
 
 ```c
 ++*ptr;


### PR DESCRIPTION
Currently the example generated C code doesn't exactly match the brain fuck input, this fixes that by making the pointer end up at the correct location (two cells to the right of the first zero cell) 